### PR TITLE
feat: Vendor libsecret and update DBus v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/byteness/keyring
 go 1.24
 
 require (
-	github.com/byteness/go-keychain v0.0.0-20250621170550-72fd1d60b0b5
+	github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/byteness/go-libsecret v0.0.0-20250705200722-75549abfe79c
 	github.com/byteness/percent v0.2.2
 	github.com/danieljoos/wincred v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/byteness/keyring
 go 1.24
 
 require (
-	github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4
+	github.com/byteness/go-keychain v0.0.0-20250621170550-72fd1d60b0b5
+	github.com/byteness/go-libsecret v0.0.0-20250705200722-75549abfe79c
 	github.com/byteness/percent v0.2.2
 	github.com/danieljoos/wincred v1.2.2
 	github.com/dvsekhvalnov/jose2go v1.8.0
-	github.com/godbus/dbus v4.1.0+incompatible
-	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sys v0.33.0
 	golang.org/x/term v0.32.0
@@ -16,7 +16,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/byteness/go-keychain v0.0.0-20250621170550-72fd1d60b0b5 h1:UU441Hz7z+/2J1M3d03z8x8QSOX9eDb0dHL6dMsmaH4=
-github.com/byteness/go-keychain v0.0.0-20250621170550-72fd1d60b0b5/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
+github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:HFl8GFmwK19hYuXB8OQ0rTO9WOCgZY9JUy964zaYawY=
+github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
 github.com/byteness/go-libsecret v0.0.0-20250705200722-75549abfe79c h1:acX3x2Ka/6jQt3inHLNUuL1IKxb/j4dNMbuL6B/N324=
 github.com/byteness/go-libsecret v0.0.0-20250705200722-75549abfe79c/go.mod h1:eVg/Qgq8PRiBljsgvBLlVpMSrLecEY8pINiVRKQYYdc=
 github.com/byteness/percent v0.2.2 h1:vnIFh8WBR1xoC+U2etz0EMB1cgp+vsK6vynqTCeDziU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:HFl8GFmwK19hYuXB8OQ0rTO9WOCgZY9JUy964zaYawY=
-github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
+github.com/byteness/go-keychain v0.0.0-20250621170550-72fd1d60b0b5 h1:UU441Hz7z+/2J1M3d03z8x8QSOX9eDb0dHL6dMsmaH4=
+github.com/byteness/go-keychain v0.0.0-20250621170550-72fd1d60b0b5/go.mod h1:9HlL8SWBRtCZE7sCNq+c3//H/oHywgSwtocmPTdOij8=
+github.com/byteness/go-libsecret v0.0.0-20250705200722-75549abfe79c h1:acX3x2Ka/6jQt3inHLNUuL1IKxb/j4dNMbuL6B/N324=
+github.com/byteness/go-libsecret v0.0.0-20250705200722-75549abfe79c/go.mod h1:eVg/Qgq8PRiBljsgvBLlVpMSrLecEY8pINiVRKQYYdc=
 github.com/byteness/percent v0.2.2 h1:vnIFh8WBR1xoC+U2etz0EMB1cgp+vsK6vynqTCeDziU=
 github.com/byteness/percent v0.2.2/go.mod h1:nwavge92FhIyfnldz4YWZD8uxPVvdh8NlzLRd1VYRDs=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
@@ -8,12 +10,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dvsekhvalnov/jose2go v1.8.0 h1:LqkkVKAlHFfH9LOEl5fe4p/zL02OhWE7pCufMBG2jLA=
 github.com/dvsekhvalnov/jose2go v1.8.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
-github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
-github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/secretservice.go
+++ b/secretservice.go
@@ -10,8 +10,8 @@ import (
 
 	"strings"
 
+	"github.com/byteness/go-libsecret"
 	"github.com/godbus/dbus/v5"
-	"github.com/gsterjov/go-libsecret"
 )
 
 func init() {

--- a/secretservice_test.go
+++ b/secretservice_test.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/gsterjov/go-libsecret"
+	"github.com/byteness/go-libsecret"
 )
 
 // NOTE: These tests are not runnable from a headless environment such as


### PR DESCRIPTION
Vendor `go-libsecret` and update DBus to v5 across all dependencies, also consolidating amount of dependencies used.