### PR TITLE
fix: prefer 1P tokens from cfg-supplied env vars

### DIFF
--- a/config.go
+++ b/config.go
@@ -87,8 +87,14 @@ type Config struct {
 	// OPConnectHost is the 1Password Connect server HTTP(S) URI
 	OPConnectHost string
 
+	// OPConnectTokenEnv is the primary environment variable from which to look up the 1Password Connect token
+	OPConnectTokenEnv string
+
 	// OPConnectTokenFunc is a function used to prompt the user for the 1Password Connect token
 	OPConnectTokenFunc PromptFunc
+
+	// OPTokenEnv is the primary environment variable from which to look up the 1Password service account token
+	OPTokenEnv string
 
 	// OPTokenFunc is a function used to prompt the user for the 1Password service account token
 	OPTokenFunc PromptFunc

--- a/opcommon.go
+++ b/opcommon.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	onepassword "github.com/1password/onepassword-sdk-go"
@@ -47,6 +48,7 @@ type OPBaseKeyring struct {
 	ItemTitlePrefix string
 	ItemTag         string
 	ItemFieldTitle  string
+	TokenEnvs       []string
 	TokenFunc       PromptFunc
 }
 
@@ -73,6 +75,12 @@ func (k *OPBaseKeyring) GetOPItemTitleFromKey(key string) string {
 }
 
 func (k *OPBaseKeyring) GetOPToken(prompt string) (string, error) {
+	for _, tokenEnv := range k.TokenEnvs {
+		token := os.Getenv(tokenEnv)
+		if token != "" {
+			return token, nil
+		}
+	}
 	if k.TokenFunc != nil {
 		return k.TokenFunc(prompt)
 	}

--- a/opconnect.go
+++ b/opconnect.go
@@ -89,6 +89,7 @@ func NewOPConnectKeyring(cfg *Config) (*OPConnectKeyring, error) {
 			ItemTitlePrefix: itemTitlePrefix,
 			ItemTag:         itemTag,
 			ItemFieldTitle:  itemFieldTitle,
+			TokenEnvs:       []string{cfg.OPConnectTokenEnv, OPConnectEnvToken},
 			TokenFunc:       cfg.OPConnectTokenFunc,
 		},
 		Host: host,
@@ -102,13 +103,9 @@ func (k *OPConnectKeyring) InitializeOPConnectClient() error {
 		return nil
 	}
 
-	token := os.Getenv(OPConnectEnvToken)
-	var err error
-	if token == "" {
-		token, err = k.GetOPToken("Enter 1Password Connect token")
-		if err != nil {
-			return err
-		}
+	token, err := k.GetOPToken("Enter 1Password Connect token")
+	if err != nil {
+		return err
 	}
 
 	k.Client = connect.NewClient(k.Host, token)

--- a/opstandard.go
+++ b/opstandard.go
@@ -89,6 +89,7 @@ func NewOPStandardKeyring(cfg *Config) (*OPStandardKeyring, error) {
 			ItemTitlePrefix: itemTitlePrefix,
 			ItemTag:         itemTag,
 			ItemFieldTitle:  itemFieldTitle,
+			TokenEnvs:       []string{cfg.OPTokenEnv, OPStandardEnvToken},
 			TokenFunc:       cfg.OPTokenFunc,
 		},
 		Timeout: timeout,
@@ -102,13 +103,9 @@ func (k *OPStandardKeyring) InitializeOPStandardClient() error {
 		return nil
 	}
 
-	token := os.Getenv(OPStandardEnvToken)
-	var err error
-	if token == "" {
-		token, err = k.GetOPToken("Enter 1Password service account token")
-		if err != nil {
-			return err
-		}
+	token, err := k.GetOPToken("Enter 1Password service account token")
+	if err != nil {
+		return err
 	}
 
 	client, err := onepassword.NewClient(


### PR DESCRIPTION
Fix env var priority issue described at https://github.com/ByteNess/aws-vault/pull/134#discussion_r2387744769.

Tested against https://github.com/ByteNess/aws-vault/pull/134.