### PR TITLE
refactor: 1Password backends can share token prompt func

### DIFF
--- a/config.go
+++ b/config.go
@@ -90,12 +90,9 @@ type Config struct {
 	// OPConnectTokenEnv is the primary environment variable from which to look up the 1Password Connect token
 	OPConnectTokenEnv string
 
-	// OPConnectTokenFunc is a function used to prompt the user for the 1Password Connect token
-	OPConnectTokenFunc PromptFunc
-
 	// OPTokenEnv is the primary environment variable from which to look up the 1Password service account token
 	OPTokenEnv string
 
-	// OPTokenFunc is a function used to prompt the user for the 1Password service account token
+	// OPTokenFunc is the function used to prompt the user for the 1Password Connect / service account token
 	OPTokenFunc PromptFunc
 }

--- a/opconnect.go
+++ b/opconnect.go
@@ -90,7 +90,7 @@ func NewOPConnectKeyring(cfg *Config) (*OPConnectKeyring, error) {
 			ItemTag:         itemTag,
 			ItemFieldTitle:  itemFieldTitle,
 			TokenEnvs:       []string{cfg.OPConnectTokenEnv, OPConnectEnvToken},
-			TokenFunc:       cfg.OPConnectTokenFunc,
+			TokenFunc:       cfg.OPTokenFunc,
 		},
 		Host: host,
 	}


### PR DESCRIPTION
Refactor config so that 1Password backends share the same token prompt function, as the token prompt function is not specific to a particular backend.