### PR TITLE
refactor: rename vault ID var to suggest UUID is required

### DIFF
--- a/opcommon.go
+++ b/opcommon.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	OPEnvVaultID            = "OP_VAULT"
+	OPEnvVaultID            = "OP_VAULT_ID"
 	OPItemFieldTitle        = "keyring"
 	OPItemTag               = "keyring"
 	OPItemTitlePrefix       = "keyring"


### PR DESCRIPTION
The 1Password vault ID env var should be named `OP_VAULT_ID`, as is done in the 1Password standard SDK examples, to more clearly suggest that the Vault _ID_ required, not the vault name.

This also better aligns with the naming of the `AWS_VAULT_OP_VAULT_ID` env var in https://github.com/ByteNess/aws-vault/pull/134.