### PR TITLE
chore: Enhance Dependabot config for Go and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,48 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
+  # Go module dependencies
+  - package-ecosystem: "gomod"
     open-pull-requests-limit: 10
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "11:00"
+    commit-message:
+      prefix: 'chore(deps)'
+    # Group minor and patch updates
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "go"
+  # GitHub Actions
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 10
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+      day: "tuesday"
+      time: "11:00"
+    commit-message:
+      prefix: 'chore(deps)'
+    # Group minor and patch updates
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github_actions"


### PR DESCRIPTION
Updated Dependabot configuration to include Go module and GitHub Actions updates with specific scheduling and grouping for minor and patch updates.