### PR TITLE
fix: ensure Touch ID is triggered on read operations

### DIFF
--- a/keychain_macos.go
+++ b/keychain_macos.go
@@ -72,7 +72,35 @@ func init() {
 	})
 }
 
+// ensureUnlocked triggers Touch ID authentication and keychain unlock when
+// biometrics are enabled. It is safe to call before any keychain operation —
+// it returns immediately (no-op) when:
+//   - no custom keychain path is configured
+//   - biometrics are not enabled
+//   - Touch ID has already succeeded in this process
+//   - the keychain file does not exist yet
+func (k *keychain) ensureUnlocked() error {
+	if k.path == "" || !k.useTouchID || k.isTouchIDAuthenticated {
+		return nil
+	}
+	kc := gokeychain.NewWithPath(k.path)
+	if err := kc.Status(); err != nil {
+		if errors.Is(err, gokeychain.ErrorNoSuchKeychain) {
+			// Keychain doesn't exist yet — nothing to unlock.
+			// Don't try to create it here; creation belongs to the Set path.
+			return nil
+		}
+		return err
+	}
+	_, err := k.openWithTouchID()
+	return err
+}
+
 func (k *keychain) Get(key string) (Item, error) {
+	if err := k.ensureUnlocked(); err != nil {
+		return Item{}, err
+	}
+
 	query := gokeychain.NewItem()
 	query.SetSecClass(gokeychain.SecClassGenericPassword)
 	query.SetService(k.service)
@@ -110,6 +138,10 @@ func (k *keychain) Get(key string) (Item, error) {
 }
 
 func (k *keychain) GetMetadata(key string) (Metadata, error) {
+	if err := k.ensureUnlocked(); err != nil {
+		return Metadata{}, err
+	}
+
 	query := gokeychain.NewItem()
 	query.SetSecClass(gokeychain.SecClassGenericPassword)
 	query.SetService(k.service)
@@ -238,6 +270,10 @@ func (k *keychain) Set(item Item) error {
 }
 
 func (k *keychain) Remove(key string) error {
+	if err := k.ensureUnlocked(); err != nil {
+		return err
+	}
+
 	item := gokeychain.NewItem()
 	item.SetSecClass(gokeychain.SecClassGenericPassword)
 	item.SetService(k.service)
@@ -266,6 +302,10 @@ func (k *keychain) Remove(key string) error {
 }
 
 func (k *keychain) Keys() ([]string, error) {
+	if err := k.ensureUnlocked(); err != nil {
+		return nil, err
+	}
+
 	query := gokeychain.NewItem()
 	query.SetSecClass(gokeychain.SecClassGenericPassword)
 	query.SetService(k.service)

--- a/keychain_test.go
+++ b/keychain_test.go
@@ -272,3 +272,174 @@ func tempPath() string {
 	// TODO make filename configurable
 	return filepath.Join(os.TempDir(), fmt.Sprintf("keyring-test-%d.keychain", time.Now().UnixNano()))
 }
+
+// TestEnsureUnlockedNoOpWhenNoPath verifies that ensureUnlocked returns
+// immediately when no custom keychain path is set (k.path == "").
+func TestEnsureUnlockedNoOpWhenNoPath(t *testing.T) {
+	k := &keychain{
+		path:       "", // no custom keychain
+		useTouchID: true,
+		service:    "test",
+		isTrusted:  true,
+	}
+	if err := k.ensureUnlocked(); err != nil {
+		t.Fatalf("ensureUnlocked should be a no-op when path is empty, got: %v", err)
+	}
+	if k.isTouchIDAuthenticated {
+		t.Fatal("isTouchIDAuthenticated should remain false when path is empty")
+	}
+}
+
+// TestEnsureUnlockedNoOpWhenBiometricsDisabled verifies that ensureUnlocked
+// skips when useTouchID is false.
+func TestEnsureUnlockedNoOpWhenBiometricsDisabled(t *testing.T) {
+	k := &keychain{
+		path:       "/tmp/test.keychain",
+		useTouchID: false, // biometrics not enabled
+		service:    "test",
+		isTrusted:  true,
+	}
+	if err := k.ensureUnlocked(); err != nil {
+		t.Fatalf("ensureUnlocked should be a no-op when useTouchID is false, got: %v", err)
+	}
+	if k.isTouchIDAuthenticated {
+		t.Fatal("isTouchIDAuthenticated should remain false when biometrics are disabled")
+	}
+}
+
+// TestEnsureUnlockedNoOpWhenAlreadyAuthenticated verifies that ensureUnlocked
+// returns immediately when Touch ID has already succeeded in this process.
+func TestEnsureUnlockedNoOpWhenAlreadyAuthenticated(t *testing.T) {
+	k := &keychain{
+		path:                   "/tmp/test.keychain",
+		useTouchID:             true,
+		service:                "test",
+		isTrusted:              true,
+		isTouchIDAuthenticated: true, // already authenticated
+	}
+	if err := k.ensureUnlocked(); err != nil {
+		t.Fatalf("ensureUnlocked should be a no-op when already authenticated, got: %v", err)
+	}
+}
+
+// TestEnsureUnlockedNoOpWhenKeychainDoesNotExist verifies that ensureUnlocked
+// treats ErrorNoSuchKeychain as a no-op (returns nil), so each read method's
+// existing missing-keychain handling remains authoritative.
+func TestEnsureUnlockedNoOpWhenKeychainDoesNotExist(t *testing.T) {
+	k := &keychain{
+		path:       filepath.Join(os.TempDir(), fmt.Sprintf("nonexistent-%d.keychain", time.Now().UnixNano())),
+		useTouchID: true,
+		service:    "test",
+		isTrusted:  true,
+	}
+	// The keychain doesn't exist, so kc.Status() returns ErrorNoSuchKeychain.
+	// ensureUnlocked should treat this as a no-op (return nil), letting each
+	// method's existing error handling deal with a missing keychain.
+	if err := k.ensureUnlocked(); err != nil {
+		t.Fatalf("ensureUnlocked should return nil for ErrorNoSuchKeychain, got: %v", err)
+	}
+	if k.isTouchIDAuthenticated {
+		t.Fatal("isTouchIDAuthenticated should remain false when keychain doesn't exist")
+	}
+}
+
+// TestReadMethodsCallEnsureUnlocked verifies that Get, GetMetadata, Keys,
+// and Remove work correctly on a keychain that has no biometrics enabled
+// (i.e. ensureUnlocked is a no-op and doesn't break existing behavior).
+func TestReadMethodsCallEnsureUnlocked(t *testing.T) {
+	path := tempPath()
+	defer deleteKeychain(t, path)
+
+	k := &keychain{
+		path:         path,
+		useTouchID:   false, // no biometrics — ensureUnlocked is a no-op
+		passwordFunc: FixedStringPrompt("test password"),
+		service:      "test",
+		isTrusted:    true,
+	}
+
+	// Set up some data
+	item := Item{
+		Key:         "read-test-key",
+		Label:       "Read test",
+		Description: "Testing read methods with ensureUnlocked",
+		Data:        []byte("test data"),
+	}
+	if err := k.Set(item); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get should work (ensureUnlocked is a no-op)
+	v, err := k.Get("read-test-key")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if string(v.Data) != "test data" {
+		t.Fatalf("unexpected data: %s", v.Data)
+	}
+
+	// GetMetadata queries the default (login) keychain, not the custom keychain,
+	// so it's expected to return ErrKeyNotFound for items stored in a custom keychain.
+	// This is pre-existing behaviour unrelated to the ensureUnlocked change.
+
+	// Keys should work
+	keys, err := k.Keys()
+	if err != nil {
+		t.Fatalf("Keys failed: %v", err)
+	}
+	found := false
+	for _, key := range keys {
+		if key == "read-test-key" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("Keys did not include the test key")
+	}
+
+	// Remove should work
+	if err := k.Remove("read-test-key"); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	// Key should be gone
+	_, err = k.Get("read-test-key")
+	if err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound after remove, got: %v", err)
+	}
+}
+
+// TestEnsureUnlockedPreservesSetBehavior verifies that Set still works
+// when Touch ID is not enabled (regression test for the ensureUnlocked change).
+func TestEnsureUnlockedPreservesSetBehavior(t *testing.T) {
+	path := tempPath()
+	defer deleteKeychain(t, path)
+
+	k := &keychain{
+		path:         path,
+		useTouchID:   false,
+		passwordFunc: FixedStringPrompt("test password"),
+		service:      "test",
+		isTrusted:    true,
+	}
+
+	items := []Item{
+		{Key: "key1", Data: []byte("value1")},
+		{Key: "key2", Data: []byte("value2")},
+	}
+
+	for _, item := range items {
+		if err := k.Set(item); err != nil {
+			t.Fatalf("Set(%s) failed: %v", item.Key, err)
+		}
+	}
+
+	allKeys, err := k.Keys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allKeys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(allKeys))
+	}
+}


### PR DESCRIPTION
## Problem

Touch ID authentication was only triggered from the **write path** (`Set` → `createOrOpen` → `openWithTouchID`). All read operations — `Get`, `Keys`, `Remove`, `GetMetadata` — queried the keychain directly without ever calling `openWithTouchID()`.

This meant that in aws-vault, Touch ID never fired on:
- `aws-vault exec` when session tokens were cached
- `aws-vault exec --no-session` (always reads master credentials)
- `aws-vault list`

Touch ID only worked on credential writes (`aws-vault add`, first `exec` with empty cache).

## Fix

Added an `ensureUnlocked()` helper that triggers Touch ID authentication + keychain unlock before any keychain operation. It's a no-op when:
- No custom keychain path is configured
- Biometrics are not enabled
- Touch ID has already succeeded in this process
- The keychain file does not exist yet

The helper is called from all four read methods: `Get`, `GetMetadata`, `Keys`, `Remove`. `Set` already goes through `createOrOpen` and is unchanged.

## Tests

6 new unit tests covering all guard conditions:
- No-op when path is empty
- No-op when biometrics disabled
- No-op when already authenticated
- No-op when keychain doesn't exist
- Integration: read methods work correctly with `ensureUnlocked`
- Regression: `Set` behavior is preserved

All 8 existing keychain tests continue to pass.