### PR TITLE
chore: remove CGO flags for Darwin

### DIFF
--- a/keychain_ios.go
+++ b/keychain_ios.go
@@ -1,4 +1,4 @@
-//go:build ios && cgo
+//go:build ios
 
 // NOTE: Due to newer versions of Go's crypto library requiring SecTrustCopyCertificateChain,
 // this requires iOS 15.0 or later.

--- a/keychain_macos.go
+++ b/keychain_macos.go
@@ -1,4 +1,4 @@
-//go:build darwin && !ios && cgo
+//go:build darwin && !ios
 
 package keyring
 


### PR DESCRIPTION
Related https://github.com/ByteNess/keyring/pull/104

1Pass SDK doesn't require CGO anymore, removing build tags 