### PR TITLE
passage: support per-keyring identities files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ ring, err := keyring.Open(keyring.Config{
   PassPrefix: "example",
   PassageIdentitiesFile: "~/.passage/identities",
 })
+if err != nil {
+  return err
+}
 ```
 
 ### Windows Hello backend

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ keyring.Config.TouchIDAccount = "cc.byteness.aws-vault.biometrics"
 keyring.Config.TouchIDService = "aws-vault"
 ```
 
+### Passage backend
+
+The Passage backend can select an identities file per keyring instance. If
+`PassageIdentitiesFile` is empty, Passage uses `PASSAGE_IDENTITIES_FILE` or its
+own default.
+
+```go
+ring, err := keyring.Open(keyring.Config{
+  AllowedBackends: []keyring.BackendType{keyring.PassageBackend},
+  PassDir: "~/.passage/store",
+  PassPrefix: "example",
+  PassageIdentitiesFile: "~/.passage/identities",
+})
+```
+
 ### Windows Hello backend
 
 The `winhello` backend stores encrypted envelopes in Windows Credential Manager.

--- a/config.go
+++ b/config.go
@@ -57,7 +57,7 @@ type Config struct {
 	// PassPrefix is a string prefix to prepend to the item path stored in pass
 	PassPrefix string
 
-	// PassageIdentitiesFile is the identities file used by passage, ~/ is resolved to the users' home dir
+	// PassageIdentitiesFile is the identities file used by passage only, ~/ is resolved to the users' home dir
 	PassageIdentitiesFile string
 
 	// WinCredPrefix is a string prefix to prepend to the key name

--- a/config.go
+++ b/config.go
@@ -57,6 +57,9 @@ type Config struct {
 	// PassPrefix is a string prefix to prepend to the item path stored in pass
 	PassPrefix string
 
+	// PassageIdentitiesFile is the identities file used by passage, ~/ is resolved to the users' home dir
+	PassageIdentitiesFile string
+
 	// WinCredPrefix is a string prefix to prepend to the key name
 	WinCredPrefix string
 

--- a/passage.go
+++ b/passage.go
@@ -44,11 +44,9 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		if passage.identitiesFile != "" {
-			passage.identitiesFile, err = ExpandTilde(passage.identitiesFile)
-			if err != nil {
-				return nil, err
-			}
+		passage.identitiesFile, err = ExpandTilde(passage.identitiesFile)
+		if err != nil {
+			return nil, err
 		}
 
 		// fail if the pass program is not available
@@ -70,9 +68,7 @@ type passageKeyring struct {
 
 func (k *passageKeyring) pass(args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(context.Background(), k.passcmd, args...)
-	if k.dir != "" || k.identitiesFile != "" {
-		cmd.Env = os.Environ()
-	}
+	cmd.Env = os.Environ()
 	if k.dir != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("PASSAGE_DIR=%s", k.dir))
 	}

--- a/passage.go
+++ b/passage.go
@@ -18,9 +18,10 @@ func init() {
 		var err error
 
 		passage := &passageKeyring{
-			passcmd: cfg.PassCmd,
-			dir:     cfg.PassDir,
-			prefix:  cfg.PassPrefix,
+			passcmd:        cfg.PassCmd,
+			dir:            cfg.PassDir,
+			prefix:         cfg.PassPrefix,
+			identitiesFile: cfg.PassageIdentitiesFile,
 		}
 
 		if passage.passcmd == "" {
@@ -43,6 +44,12 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
+		if passage.identitiesFile != "" {
+			passage.identitiesFile, err = ExpandTilde(passage.identitiesFile)
+			if err != nil {
+				return nil, err
+			}
+		}
 
 		// fail if the pass program is not available
 		_, err = exec.LookPath(passage.passcmd)
@@ -55,15 +62,22 @@ func init() {
 }
 
 type passageKeyring struct {
-	dir     string
-	passcmd string
-	prefix  string
+	dir            string
+	passcmd        string
+	prefix         string
+	identitiesFile string
 }
 
 func (k *passageKeyring) pass(args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(context.Background(), k.passcmd, args...)
+	if k.dir != "" || k.identitiesFile != "" {
+		cmd.Env = os.Environ()
+	}
 	if k.dir != "" {
-		cmd.Env = append(os.Environ(), fmt.Sprintf("PASSAGE_DIR=%s", k.dir))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PASSAGE_DIR=%s", k.dir))
+	}
+	if k.identitiesFile != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PASSAGE_IDENTITIES_FILE=%s", k.identitiesFile))
 	}
 	cmd.Stderr = os.Stderr
 

--- a/passage_test.go
+++ b/passage_test.go
@@ -65,6 +65,36 @@ func TestPassageKeyringSetWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestPassageKeyringUsesConfiguredIdentitiesFile(t *testing.T) {
+	k, teardown := passageSetup(t)
+	defer teardown(t)
+
+	identityFile := os.Getenv("PASSAGE_IDENTITIES_FILE")
+	t.Setenv("PASSAGE_IDENTITIES_FILE", filepath.Join(filepath.Dir(k.dir), "missing-identities"))
+	ring, err := Open(Config{
+		AllowedBackends:       []BackendType{PassageBackend},
+		PassDir:               k.dir,
+		PassPrefix:            k.prefix,
+		PassageIdentitiesFile: identityFile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	item := Item{Key: "llamas", Data: []byte("llamas are great")}
+	if err := ring.Set(item); err != nil {
+		t.Fatal(err)
+	}
+
+	foundItem, err := ring.Get(item.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(foundItem.Data, item.Data) {
+		t.Fatalf("Value stored was not the value retrieved: %q", foundItem.Data)
+	}
+}
+
 func TestPassageKeyringKeysWhenEmpty(t *testing.T) {
 	k, teardown := passageSetup(t)
 	defer teardown(t)


### PR DESCRIPTION
Related to ByteNess/aws-vault#433.

Adds `PassageIdentitiesFile` to `Config`, allowing each Passage keyring instance to set `PASSAGE_IDENTITIES_FILE`. When unset, the existing inherited environment behavior is preserved.

## Verification

- `go test ./...`
- Built a local aws-vault with a `--passage-identities-file` option, linked against this keyring checkout
  - Working on [here](https://github.com/issei-m/aws-vault/compare/main...codex/separate-session-keyring), not an PR opened yet
- Verified integration with two independent age identities:

```bash
mkdir -p /tmp/aws-vault/credentials

age-keygen -o /tmp/aws-vault/key.txt
age-keygen -o /tmp/aws-vault/key2.txt

{
  age-keygen -y /tmp/aws-vault/key.txt
  age-keygen -y /tmp/aws-vault/key2.txt
} > /tmp/aws-vault/credentials/.age-recipients

aws-vault \
  --backend=passage \
  --pass-dir=/tmp/aws-vault/credentials \
  --passage-identities-file=/tmp/aws-vault/key.txt \
  add test

aws-vault \
  --backend=passage \
  --pass-dir=/tmp/aws-vault/credentials \
  --passage-identities-file=/tmp/aws-vault/key.txt \
  exec --no-session test -- env

aws-vault \
  --backend=passage \
  --pass-dir=/tmp/aws-vault/credentials \
  --passage-identities-file=/tmp/aws-vault/key2.txt \
  exec --no-session test -- env
```

Both identities successfully decrypted the stored credential.

## AI disclosure

OpenAI Codex assisted with the implementation, tests, documentation, and drafting this PR. I reviewed the complete diff and manually performed the integration test above.
